### PR TITLE
Add DNS server configuration and backup VM

### DIFF
--- a/backup_vm.tf
+++ b/backup_vm.tf
@@ -1,0 +1,41 @@
+/*
+
+I want to create a second VM that will be used for backup purpose.
+This VM should be created in the same resource group as the first VM.
+This VM should be created in the same virtual network as the first VM.
+
+
+*/
+
+resource "azurerm_virtual_machine" "backup_vm" {
+  name                  = "backup_vm"
+  location              = azurerm_resource_group.rg.location
+  resource_group_name   = azurerm_resource_group.rg.name
+
+  network_interface_ids = [azurerm_network_interface.nic.id]
+  vm_size               = "Standard_DS1_v2"
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04.0-LTS"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name              = "myosdisk2"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  os_profile {
+    computer_name  = "hostname"
+    admin_username = "adminuser"
+    admin_password = "Password1234!"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,8 @@ resource "azurerm_virtual_network" "ghes_network" {
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.ghes_rg.location
   resource_group_name = azurerm_resource_group.ghes_rg.name
+
+   dns_servers = ["1.1.1.1"]  
 }
 
 # Create subnet


### PR DESCRIPTION
This pull request includes changes to the Terraform configuration files `backup_vm.tf` and `main.tf`. The changes introduce a new backup virtual machine (VM) and modify the virtual network configuration.

The most important changes include:

* [`backup_vm.tf`](diffhunk://#diff-9313056c1b8cdf2e73b0e785d8b848aa71b2e81445c38fc83880f7dfe7f55b34R1-R41): A new backup VM is created in the same resource group and virtual network as the first VM. The VM is configured with an Ubuntu Server image, a standard disk type, and basic OS profile settings.
* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR18-R19): The `dns_servers` attribute in the `azurerm_virtual_network` resource is updated to include a new DNS server.